### PR TITLE
feat(https): 支持 certbot webroot 模式

### DIFF
--- a/src/frontend/default.conf.ssl.template
+++ b/src/frontend/default.conf.ssl.template
@@ -27,7 +27,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	    proxy_set_header   Host                 $http_host;
         proxy_set_header   X-Forwarded-Proto    $scheme;
-          
+
         client_max_body_size 512M;
     }
     location ~ .*\.(js|json|css)$ {
@@ -47,5 +47,9 @@ server {
         alias   /usr/share/nginx/scrollBoard;
         try_files $uri $uri/ /index.html;
         index index.html index.htm;
+    }
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+        allow all;
     }
 }

--- a/src/frontend/default.conf.ssl.template
+++ b/src/frontend/default.conf.ssl.template
@@ -2,8 +2,17 @@ server {
     listen 80;
     #填写绑定证书的域名
     server_name ${SERVER_NAME};
+
+    # 支持 certbot webroot verification (必须在 80 端口)
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+        allow all;
+    }
+
     #把http的域名请求转成https
-    return 301 https://$host$request_uri;
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {
@@ -47,9 +56,5 @@ server {
         alias   /usr/share/nginx/scrollBoard;
         try_files $uri $uri/ /index.html;
         index index.html index.htm;
-    }
-    location ^~ /.well-known/acme-challenge/ {
-        root /usr/share/nginx/html;
-        allow all;
     }
 }


### PR DESCRIPTION
增加 nginx 对于 certbot webroot 模式的支持，以便启动定时任务自动续期 https 证书。

引用原文如下：
https://certbot.eff.org/instructions?ws=webproduct&os=snap

> To use the webroot plugin, your server must be configured to serve files from hidden directories. If /.well-known is treated specially by your webserver configuration, you might need to modify the configuration to ensure that files inside /.well-known/acme-challenge are served by the webserver.

修改后允许 certbot 续期证书时访问如下路径。
```
curl http://www.xxx.xxx/.well-known/acme-challenge/test
test
```